### PR TITLE
[feat]: 테마 생성할 때 테마 생성 사용자 데이터와 태그 저장 (#1)

### DIFF
--- a/navi_backend/themes/views.py
+++ b/navi_backend/themes/views.py
@@ -7,7 +7,7 @@ from rest_framework import status
 from django.shortcuts import get_object_or_404
 from django.db.models import Count
 from .serializers import ThemeCreateSerializer, ThemeListSerializer, ThemeDetailSerializer, MainPageSerializer
-from .models import Theme
+from .models import Theme, Tag
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 
@@ -24,14 +24,20 @@ theme_id_response = openapi.Response('int : theme_id')
     request_body=ThemeCreateSerializer,
     responses={201: theme_id_response},
 )
+
+# 테마 생성 api
 @api_view(['POST'])
 def create(request):
 
     serializer = ThemeCreateSerializer(data=request.data)
 
     if serializer.is_valid(raise_exception=True):
-        theme = serializer.save()
-
+        theme = serializer.save(theme_creator=request.user)
+        tags = request.data.get('theme_tags')
+        for tag_name in tags:
+            tag = Tag.objects.get_or_create(tag_name=tag_name)
+            theme.theme_tags.add(tag)
+        
     data = {
         'theme_id': theme.id,
     }


### PR DESCRIPTION
## 이슈

resolve #1

## 작업 사항
- 테마를 생성한 사용자 데이터를 저장합니다.
- 테마 태그들을 저장합니다.

## 참고 사항
- 아직 로그인을 할 수가 없어 테스트가 진행되지 않았습니다.
- 기능이 잘 동작하지 않는다면 comment를 남겨주세요
